### PR TITLE
Bump log level to INFO for interesting logs

### DIFF
--- a/lib/db2kafka/record_publisher.ex
+++ b/lib/db2kafka/record_publisher.ex
@@ -51,7 +51,7 @@ defmodule Db2Kafka.RecordPublisher do
     case result do
      [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0}]}] ->
         Db2Kafka.Stats.incrementSuccess(@publish_records_metric)
-        _ = Logger.debug("Published batch of #{length(records)} records to topic #{topic} partition #{partition_id}")
+        _ = Logger.info("Published batch of #{length(records)} records to topic #{topic} partition #{partition_id}")
         Db2Kafka.Stats.incrementCountBy(@records_published_metric, length(records), ["topic:#{topic}"])
         Db2Kafka.Stats.timer(@publish_latency_metric, Db2Kafka.Record.age(Enum.at(records, -1)))
         {:reply, :ok, kafka_pid}


### PR DESCRIPTION
In order to reduce the amount of logging produced by db2kafka, we are using a Logger config switch to remove all `debug` level logs:

```
config :logger,
  compile_time_purge_level: :info
```
See https://hexdocs.pm/logger/Logger.html for documentation.

This PR bumps the logging levels of logs we still care about to `info` so that we don't lose them when we purge `debug` logs.