### PR TITLE
Delete records destined for unknown (unconfigured) topics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: elixir
 elixir:
-  - 1.3.4
+  - 1.4.0
 otp_release:
   - 19.1
 # https://github.com/travis-ci/travis-ci/issues/6116

--- a/lib/db2kafka/record_buffer.ex
+++ b/lib/db2kafka/record_buffer.ex
@@ -104,7 +104,7 @@ defmodule Db2Kafka.RecordBuffer do
 
     records_to_delete_length = length(records_to_delete)
     if records_to_delete_length > 0 do
-      Db2Kafka.RecordDeleter.delete_records(records_to_delete)
+      Db2Kafka.RecordDeleter.delete_records(records_to_delete, false)
       Db2Kafka.Stats.incrementCountBy(@unknown_topic_records_metric, records_to_delete_length)
     end
 

--- a/lib/db2kafka/record_buffer.ex
+++ b/lib/db2kafka/record_buffer.ex
@@ -102,8 +102,11 @@ defmodule Db2Kafka.RecordBuffer do
     known_topics = Application.get_env(:db2kafka, :topics)
     {records_in_known_topics, records_to_delete} = Enum.split_with(records, fn(r) -> Enum.member?(known_topics, r.topic) end)
 
-    Db2Kafka.RecordDeleter.delete_records(records_to_delete)
-    Db2Kafka.Stats.incrementCountBy(@unknown_topic_records_metric, length(records_to_delete))
+    records_to_delete_length = length(records_to_delete)
+    if records_to_delete_length > 0 do
+      Db2Kafka.RecordDeleter.delete_records(records_to_delete)
+      Db2Kafka.Stats.incrementCountBy(@unknown_topic_records_metric, records_to_delete_length)
+    end
 
     buckets = records_to_ordered_topic_buckets(records_in_known_topics)
 

--- a/lib/db2kafka/record_buffer.ex
+++ b/lib/db2kafka/record_buffer.ex
@@ -8,6 +8,7 @@ defmodule Db2Kafka.RecordBuffer do
 
   @records_served_metric "db2kafka.buffer.records_served"
   @duplicates_metric "db2kafka.buffer.duplicates"
+  @unknown_topic_records_metric "db2kafka.buffer.unknown_topic_records"
 
   @type record_result :: {:ok, [%Db2Kafka.Record{}]} | {:error, String.t | :no_record}
 
@@ -102,6 +103,7 @@ defmodule Db2Kafka.RecordBuffer do
     {records_in_known_topics, records_to_delete} = Enum.split_with(records, fn(r) -> Enum.member?(known_topics, r.topic) end)
 
     Db2Kafka.RecordDeleter.delete_records(records_to_delete)
+    Db2Kafka.Stats.incrementCountBy(@unknown_topic_records_metric, length(records_to_delete))
 
     buckets = records_to_ordered_topic_buckets(records_in_known_topics)
 

--- a/lib/db2kafka/record_deleter.ex
+++ b/lib/db2kafka/record_deleter.ex
@@ -49,7 +49,7 @@ defmodule Db2Kafka.RecordDeleter do
     )
   end
 
-  def handle_cast({:delete_records, records}, _from, db_pid) do
+  def handle_cast({:delete_records, records}, db_pid) do
     do_delete_records(records, db_pid)
     {:noreply, db_pid}
   end

--- a/lib/db2kafka/record_deleter.ex
+++ b/lib/db2kafka/record_deleter.ex
@@ -34,18 +34,32 @@ defmodule Db2Kafka.RecordDeleter do
     {:ok, db_pid}
   end
 
-  @spec delete_records(list(Db2Kafka.Record.t)) :: atom
-  def delete_records(records) do
+  @spec delete_records(list(Db2Kafka.Record.t), boolean) :: atom
+  def delete_records(records, sync \\ true) do
     :poolboy.transaction(
       Db2Kafka.Supervisor.deleter_pool_name,
       fn(pid) ->
-        GenServer.call(pid, {:delete_records, records})
+        if sync do
+          GenServer.call(pid, {:delete_records, records})
+        else
+          GenServer.cast(pid, {:delete_records, records})
+        end
       end,
       :infinity
     )
   end
 
+  def handle_cast({:delete_records, records}, _from, db_pid) do
+    do_delete_records(records, db_pid)
+    {:noreply, db_pid}
+  end
+
   def handle_call({:delete_records, records}, _from, db_pid) do
+    result = do_delete_records(records, db_pid)
+    {:reply, result, db_pid}
+  end
+
+  def do_delete_records(records, db_pid) do
     joined_record_ids = Enum.map(records, fn(record) -> record.id end)
       |> Enum.join(", ")
 
@@ -77,6 +91,6 @@ defmodule Db2Kafka.RecordDeleter do
 
     :ok = Db2Kafka.RecordBuffer.remove_downstream_records(records)
 
-    {:reply, deletion_result, db_pid}
+    deletion_result
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Db2Kafka.Mixfile do
 
   def project do
     [app: :db2kafka,
-     version: "0.1.0",
+     version: "0.2.0",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Db2Kafka.Mixfile do
   def project do
     [app: :db2kafka,
      version: "0.1.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps,

--- a/test/db2kafka/record_buffer_test.exs
+++ b/test/db2kafka/record_buffer_test.exs
@@ -44,7 +44,7 @@ defmodule Db2Kafka.RecordBufferTest do
 
   @tag :unit
   test_with_mock ":get_records_result only buckets records from a known topic, and deletes the others",
-    Db2Kafka.RecordDeleter, [], [delete_records: fn(_) -> {:ok, []} end] do
+    Db2Kafka.RecordDeleter, [], [delete_records: fn(_, _) -> {:ok, []} end] do
 
     known_topics = ["foo", "bar"]
 
@@ -64,7 +64,7 @@ defmodule Db2Kafka.RecordBufferTest do
 
       assert state1 == %Db2Kafka.RecordBuffer{buckets: expected_buckets, downstream_ids: expected_downstream_ids, fetching_records: false}
 
-      assert called Db2Kafka.RecordDeleter.delete_records([r3, r4])
+      assert called Db2Kafka.RecordDeleter.delete_records([r3, r4], false)
     end
   end
 

--- a/test/db2kafka/record_buffer_test.exs
+++ b/test/db2kafka/record_buffer_test.exs
@@ -43,6 +43,32 @@ defmodule Db2Kafka.RecordBufferTest do
   end
 
   @tag :unit
+  test_with_mock ":get_records_result only buckets records from a known topic, and deletes the others",
+    Db2Kafka.RecordDeleter, [], [delete_records: fn(_) -> {:ok, []} end] do
+
+    known_topics = ["foo", "bar"]
+
+    with_mock Application, [], [get_env: fn(_, _) -> known_topics end] do
+
+      r1 = %Db2Kafka.Record{id: 1, topic: "foo", partition_key: "k-1-f", body: "Abc"}
+      r2 = %Db2Kafka.Record{id: 2, topic: "bar", partition_key: "k-2-b", body: "Def"}
+      r3 = %Db2Kafka.Record{id: 3, topic: "baz", partition_key: "k-3-b", body: "Ghi"}
+      r4 = %Db2Kafka.Record{id: 4, topic: "baz", partition_key: "k-4-b", body: "Ghi"}
+
+      buckets0 = %{}
+
+      {:noreply, state1} = Db2Kafka.RecordBuffer.handle_cast({:get_records_result, {:ok, [r1, r2, r3, r4]}}, nil)
+
+      expected_buckets = Db2Kafka.RecordBuffer.records_to_ordered_topic_buckets([r1, r2])
+      expected_downstream_ids = make_downstream_ids([r1, r2, r3, r4])
+
+      assert state1 == %Db2Kafka.RecordBuffer{buckets: expected_buckets, downstream_ids: expected_downstream_ids, fetching_records: false}
+
+      assert called Db2Kafka.RecordDeleter.delete_records([r3, r4])
+    end
+  end
+
+  @tag :unit
   test "records_to_ordered_topic_buckets should group by topic, ordered by id" do
 
     records = [

--- a/test/db2kafka/record_deleter_test.exs
+++ b/test/db2kafka/record_deleter_test.exs
@@ -19,4 +19,20 @@ defmodule Db2Kafka.RecordDeleterTest do
       assert_eventually(fn -> called(Mariaex.query(:_, expected_query)) end)
     end
   end
+
+  @tag :unit
+  test_with_mock "it deletes records asynchronously", _context,
+    Mariaex, [], [query: fn(_, _) -> {:ok, %Mariaex.Result{num_rows: 1}} end,
+                  start_link: fn(_) -> {:ok, :db_pid} end] do
+    with_mock Db2Kafka.RecordBuffer, [], [remove_downstream_records: fn(_) -> :ok end] do
+
+      records = [%Db2Kafka.Record{id: 45, created_at: :erlang.system_time},
+                 %Db2Kafka.Record{id: 47, created_at: :erlang.system_time}]
+      {:ok, pid} = Db2Kafka.RecordDeleter.start_link([])
+      GenServer.cast(pid, {:delete_records, records})
+
+      expected_query = "DELETE FROM outbound_kafka_queue WHERE id IN (45, 47)"
+      assert_eventually(fn -> called(Mariaex.query(:_, expected_query)) end)
+    end
+  end
 end


### PR DESCRIPTION
Currently, when db2kafka encounters a record for a topic it's not configured for, it freezes up entirely (because there's no process hierarchy for the record, so it doesn't even get removed from the `RecordBuffer`, so `RecordBuffer` never queries the DB for more records).

This PR changes the behaviour of the `RecordBuffer` such that ingested records for an unknown topic are immediately sent to the `RecordDeleter`. The `RecordDeleter` will delete them from the DB and then instruct the `RecordBuffer` to `remove_downstream_records`. In this way, db2kafka will continue working.