### PR TITLE
Migrate from kafka_ex to brod using kaffe (elixir wrapper)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ erl_crash.dump
 # PLT cache dir
 .plts
 doc
+
+# vim files
+.*.sw?

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,12 +22,13 @@ config :db2kafka,
   primary_region: System.get_env("PRIMARY_REGION") || "us-west-2",       # The preferred region
   region: System.get_env("REGION") || "us-west-2"                        # Region this app is running in
 
-config :kafka_ex,
-  brokers: [
-    { System.get_env("BROKER_HOST") || "localhost",                      # A Kafka bootstrap broker hostname
-     (System.get_env("BROKER_PORT") || "9092") |> String.to_integer}     # A Kafka bootstrap broker port
-  ],
-  # Tweak kafka_ex for our needs - don't override unless you know exactly what's going on!
-  consumer_group: :no_consumer_group,
-  disable_default_worker: false
-
+config :kaffe,
+  producer: [
+    endpoints: [
+      {((System.get_env("BROKER_HOST") || "localhost") |> String.to_atom),
+        (System.get_env("BROKER_PORT") || "9092") |> String.to_integer
+      }
+    ], # [hostname: port]
+    required_acks: -1,
+    topics: (System.get_env("TOPICS") || "foo") |> String.split(","),
+  ]

--- a/lib/db2kafka/record_publisher.ex
+++ b/lib/db2kafka/record_publisher.ex
@@ -13,16 +13,6 @@ defmodule Db2Kafka.RecordPublisher do
     GenServer.start_link(__MODULE__, :ok, [])
   end
 
-  def init(:ok) do
-    GenServer.start_link(KafkaEx.Server,
-      [
-        [uris: Application.get_env(:kafka_ex, :brokers),
-         consumer_group: Application.get_env(:kafka_ex, :consumer_group)],
-        :no_name
-      ]
-    )
-  end
-
   @spec publish_records(String.t, non_neg_integer, list(Db2Kafka.Record.t)) :: atom
   def publish_records(topic, partition_id, records) do
     :poolboy.transaction(
@@ -37,19 +27,11 @@ defmodule Db2Kafka.RecordPublisher do
   def handle_call({:publish_records, topic, partition_id, records}, _from, kafka_pid) do
     length(records) |> Db2Kafka.Stats.histogram(@publish_batch_size_metric)
     result = Db2Kafka.Stats.timing(@publish_records_metric, fn ->
-      produce_request = %KafkaEx.Protocol.Produce.Request{
-        topic: topic,
-        partition: partition_id,
-        required_acks: -1,
-        timeout: 3_000,
-        compression: :none,
-        messages: Enum.map(records, fn(r) -> %KafkaEx.Protocol.Produce.Message{key: "", value: r.body} end)
-      }
-      KafkaEx.produce(produce_request, [worker_name: kafka_pid])
+      Kaffe.Producer.produce_sync(topic, partition_id, Enum.map(records, fn(r) -> {"", r.body} end))
     end)
 
     case result do
-     [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0}]}] ->
+      :ok ->
         Db2Kafka.Stats.incrementSuccess(@publish_records_metric)
         _ = Logger.info("Published batch of #{length(records)} records to topic #{topic} partition #{partition_id}")
         Db2Kafka.Stats.incrementCountBy(@records_published_metric, length(records), ["topic:#{topic}"])

--- a/lib/db2kafka/topic_supervisor.ex
+++ b/lib/db2kafka/topic_supervisor.ex
@@ -10,8 +10,12 @@ defmodule Db2Kafka.TopicSupervisor do
   end
 
   defp get_num_partitions(topic) do
-    topic_metadata = hd(KafkaEx.metadata(topic: topic).topic_metadatas)
-    length(topic_metadata.partition_metadatas)
+    endpoints = Application.get_env(:kaffe, :producer)[:endpoints]
+    {:ok, metadata} = :brod.get_metadata(endpoints, [topic])
+    {:kpro_MetadataResponse, _ ,
+      [{:kpro_TopicMetadata, _, ^topic, partition_metadata}]} = metadata
+
+    length(partition_metadata)
   end
 
   def init(topic) do

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Db2Kafka.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :kafka_ex, :ex_statsd, :crypto, :poolboy],
+    [applications: [:logger, :ex_statsd, :crypto, :poolboy, :kaffe],
      included_applications: [:mariaex, :murmur, :poison, :erlzk],
      mod: {Db2Kafka, []}
     ]
@@ -25,7 +25,6 @@ defmodule Db2Kafka.Mixfile do
   defp deps do
     [
       {:mock, "~> 0.1.1", only: :test},
-      {:kafka_ex, "~> 0.5.0"},
       {:murmur, "~> 1.0"},
       {:mariaex, "~> 0.7.3"},
       {:ex_statsd, github: "PagerDuty/ex_statsd", ref: "a5c1aefd1d8d273e3910c2ae53c034669f792400"}, # Pulling in socket open fix
@@ -33,7 +32,8 @@ defmodule Db2Kafka.Mixfile do
       {:dialyxir, "~> 0.3.5", only: [:dev]},
       {:poison, "~> 2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:erlzk, "~> 0.6.3"}
+      {:erlzk, "~> 0.6.3"},
+      {:kaffe, "~> 1.0", github: "PagerDuty/kaffe", ref: "18c867ee2ba2613e2c227a4e7d44c84bf36189ad"}
     ]
   end
 

--- a/test/db2kafka/record_publisher_test.exs
+++ b/test/db2kafka/record_publisher_test.exs
@@ -13,19 +13,18 @@ defmodule Db2Kafka.RecordPublisherTest do
   end
 
   setup do
-    records = [%Db2Kafka.Record{id: 1, created_at: :erlang.system_time},
-               %Db2Kafka.Record{id: 2, created_at: :erlang.system_time}]
+    records = [%Db2Kafka.Record{id: 1, created_at: :erlang.system_time, body: "body1"},
+               %Db2Kafka.Record{id: 2, created_at: :erlang.system_time, body: "body2"}]
+    records_mapped = [
+      {"", "body1"},
+      {"", "body2"},
+    ]
+
     topic = "foo"
     partition = 0
 
-    kafka_ex_mock = [
-      produce: fn(_, _) -> [%KafkaEx.Protocol.Produce.Response{partitions: [%{error_code: 0, offset: 101, partition: 0}], topic: topic}] end,
-      metadata: fn(^topic) -> %MockMetadataResponse{
-        topic_metadatas: [%MockTopicMetadataResponse{
-          partition_metadatas: [1]
-        }]
-      } end,
-      create_worker: fn(_) -> {:ok, :worker} end
+    kaffe_producer_mock = [
+      produce_sync: fn(_, _, _) -> :ok end
     ]
 
     topic_buffer_mock = [
@@ -35,18 +34,19 @@ defmodule Db2Kafka.RecordPublisherTest do
     {
       :ok,
       records: records,
+      records_mapped: records_mapped,
       partition: partition,
       topic: topic,
-      kafka_ex_mock: kafka_ex_mock,
+      kaffe_producer_mock: kaffe_producer_mock,
       topic_buffer_mock: topic_buffer_mock
     }
   end
 
   @tag :unit
   test_with_mock "it publishes records",
-      %{records: records, partition: partition, topic: topic, kafka_ex_mock: kafka_ex_mock},
-      KafkaEx, [], kafka_ex_mock do
+      %{records: records, records_mapped: records_mapped, partition: partition, topic: topic, kaffe_producer_mock: kaffe_producer_mock},
+      Kaffe.Producer, [], kaffe_producer_mock do
     Db2Kafka.RecordPublisher.handle_call({:publish_records, topic, partition, records}, self(), :kafka_pid)
-    assert_eventually(fn -> called(KafkaEx.produce(:_, [worker_name: :kafka_pid])) end)
+    assert_eventually(fn -> called(Kaffe.Producer.produce_sync(topic, partition, records_mapped)) end)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -57,6 +57,7 @@ defmodule TestHelpers do
     Logger.info("Starting applications")
     Db2Kafka.Mixfile.application[:applications]
       |> Enum.map(&Application.start(&1))
+      Application.ensure_all_started(:kaffe)
     Db2Kafka.start
   end
 end


### PR DESCRIPTION
This PR depends on: https://github.com/spreedly/kaffe/pull/38. Since it hasn't been merged yet, the dependency is pointing directly to the commit hash.