### PR TITLE
Add two new metrics for latency sla measurements

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,7 +20,9 @@ config :db2kafka,
   ],
   barrier_path: "/db2kafka_failover_barrier",
   primary_region: System.get_env("PRIMARY_REGION") || "us-west-2",       # The preferred region
-  region: System.get_env("REGION") || "us-west-2"                        # Region this app is running in
+  region: System.get_env("REGION") || "us-west-2",                       # Region this app is running in
+  publish_latency_sla_95perc_threshold_ms: 10000,
+  publish_latency_sla_max_threshold_ms: 30000
 
 config :kafka_ex,
   brokers: [

--- a/lib/db2kafka/record_publisher.ex
+++ b/lib/db2kafka/record_publisher.ex
@@ -6,6 +6,8 @@ defmodule Db2Kafka.RecordPublisher do
   @records_published_metric "db2kafka.records_published"
   @publish_latency_metric "db2kafka.publish_latency"
   @publish_batch_size_metric "db2kafka.publish_batch_size"
+  @publish_latency_records_over_95percentile_metric "db2kafka.publish_latency_records_over_95percentile"
+  @publish_latency_records_over_max_metric "db2kafka.publish_latency_records_over_max"
 
   @spec start_link([]) :: GenServer.on_start
   def start_link([]) do
@@ -53,7 +55,14 @@ defmodule Db2Kafka.RecordPublisher do
         Db2Kafka.Stats.incrementSuccess(@publish_records_metric)
         _ = Logger.info("Published batch of #{length(records)} records to topic #{topic} partition #{partition_id}")
         Db2Kafka.Stats.incrementCountBy(@records_published_metric, length(records), ["topic:#{topic}"])
-        Db2Kafka.Stats.timer(@publish_latency_metric, Db2Kafka.Record.age(Enum.at(records, -1)))
+        age = Db2Kafka.Record.age(Enum.at(records, -1))
+        Db2Kafka.Stats.timer(@publish_latency_metric, age)
+        if age > Application.get_env(:db2kafka, :publish_latency_sla_95percentile) do
+          Db2Kafka.Stats.incrementCountBy(@publish_latency_records_over_95percentile_metric, length(records), ["topic:#{topic}"])
+          if age > Application.get_env(:db2kafka, :publish_latency_sla_max) do
+            Db2Kafka.Stats.incrementCountBy(@publish_latency_records_over_max_metric, length(records), ["topic:#{topic}"])
+          end
+        end
         {:reply, :ok, kafka_pid}
       _ ->
         Db2Kafka.Stats.incrementFailure(@publish_records_metric)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Db2Kafka.Mixfile do
 
   def project do
     [app: :db2kafka,
-     version: "0.4.0",
+     version: "0.5.0",
      elixir: "~> 1.4.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Two new metrics:
- db2kafka.publish_latency_records_over_95percentile
- db2kafka.publish_latency_records_over_max

to measure the amount of records published which took longer than some latency values set in the environment (`publish_latency_sla_95percentile`, `publish_latency_sla_max`)